### PR TITLE
MetrixHDXPicon fix possible crash when image file corrupt

### DIFF
--- a/usr/lib/enigma2/python/Components/Renderer/MetrixHDXPicon.py
+++ b/usr/lib/enigma2/python/Components/Renderer/MetrixHDXPicon.py
@@ -113,7 +113,16 @@ class MetrixHDXPicon(Renderer):
 						self.nameCache["default"] = pngname
 				if self.pngname != pngname:
 					if config.plugins.MyMetrixLiteOther.piconresize_experimental.value:
-						im = Image.open(pngname).convert('RGBA')
+						try:
+							im = Image.open(pngname).convert('RGBA')
+						except:
+							print "[MetrixHDXPicon] cant load image:",pngname
+							tmp = resolveFilename(SCOPE_CURRENT_SKIN, "picon_default.png")
+							if fileExists(tmp):
+								pngname = tmp
+							else:
+								pngname = resolveFilename(SCOPE_SKIN_IMAGE, "skin_default/picon_default.png")
+							im = Image.open(pngname).convert('RGBA')
 						imw, imh = im.size
 						inh = self.instance.size().height()
 						if imh != inh:


### PR DESCRIPTION
File .../git/usr/lib/enigma2/python/Components/Renderer/MetrixHDXPicon.py", line 116, in changed
File "/usr/lib/python2.7/site-packages/PIL/Image.py", line 1980, in open
IOError: cannot identify image file